### PR TITLE
Remove Window entries when not needed.

### DIFF
--- a/src/me/islandscout/hawk/module/GUIManager.java
+++ b/src/me/islandscout/hawk/module/GUIManager.java
@@ -84,4 +84,12 @@ public class GUIManager implements Listener {
             }
         }
     }
+    
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event){
+        if (!(event.getPlayer() instanceof Player)) return;
+        
+        if (activeWindows.containsKey(event.getPlayer().getUniqueId())){
+            activeWindows.remove(event.getPlayer().getUniqueId());
+        }
 }


### PR DESCRIPTION
Basically it is pointless to have extra data in a map when it is not needed.