### PR TITLE
Revert "Remove Window entries when not needed."

### DIFF
--- a/src/me/islandscout/hawk/module/GUIManager.java
+++ b/src/me/islandscout/hawk/module/GUIManager.java
@@ -85,16 +85,7 @@ public class GUIManager implements Listener {
             }
         }
     }
-    
-    @EventHandler
-    public void onInventoryClose(InventoryCloseEvent event){
-        if (!(event.getPlayer() instanceof Player)) return;
-        
-        if (activeWindows.containsKey(event.getPlayer().getUniqueId())){
-            activeWindows.remove(event.getPlayer().getUniqueId());
-        }
-    }
-  
+
     public void stop() {
         for(UUID uuid : activeWindows.keySet()) {
             Player p = Bukkit.getPlayer(uuid);


### PR DESCRIPTION
Will break GUI if we remove entries on close: every time the window updates, the GUI will no longer function.