### PR TITLE
PacketEvents support

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,7 +4,9 @@ version: BETA 2012 (DEV)
 author: Islandscout
 description: An anticheat system
 website: https://github.com/HawkAnticheat/Hawk
-softdepend: [ProtocolLib]
+softdepend:
+  - ProtocolLib
+  - packetevents
 commands:
     hawk:
         description: Basic information about Hawk Anticheat

--- a/src/me/islandscout/hawk/Hawk.java
+++ b/src/me/islandscout/hawk/Hawk.java
@@ -65,6 +65,7 @@ public class Hawk extends JavaPlugin {
     public static final String BASE_PERMISSION = "hawk";
     public static String BUILD_NAME;
     public static String FLAG_CLICK_COMMAND;
+    public static boolean USING_PACKETEVENTS;
     public static boolean USING_PLIB;
     public static final String NO_PERMISSION = ChatColor.RED + "You do not have permission \"%s\" to perform this action.";
     private boolean sendJSONMessages;
@@ -88,9 +89,11 @@ public class Hawk extends JavaPlugin {
 
     public void loadModules() {
         getLogger().info("Loading modules...");
-
-        USING_PLIB = getServer().getPluginManager().isPluginEnabled("ProtocolLib");
-
+        //Prioritize packetevents
+        USING_PACKETEVENTS = getServer().getPluginManager().isPluginEnabled("packetevents");
+        if (!USING_PACKETEVENTS) {
+            USING_PLIB = getServer().getPluginManager().isPluginEnabled("ProtocolLib");
+        }
         new File(plugin.getDataFolder().getAbsolutePath()).mkdirs();
         messages = YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder().getAbsolutePath() + File.separator + "messages.yml"));
         checksConfig = YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder().getAbsolutePath() + File.separator + "checks.yml"));

--- a/src/me/islandscout/hawk/util/ServerUtils.java
+++ b/src/me/islandscout/hawk/util/ServerUtils.java
@@ -19,6 +19,7 @@
 package me.islandscout.hawk.util;
 
 import com.comphenix.protocol.ProtocolLibrary;
+import io.github.retrooper.packetevents.PacketEvents;
 import me.islandscout.hawk.Hawk;
 import me.islandscout.hawk.HawkPlayer;
 import me.islandscout.hawk.wrap.block.WrappedBlock;
@@ -43,8 +44,11 @@ public final class ServerUtils {
     }
 
     public static int getProtocolVersion(Player p) {
-        if(Hawk.USING_PLIB)
+        if (Hawk.USING_PACKETEVENTS) {
+            return PacketEvents.get().getPlayerUtils().getClientVersion(p).getProtocolVersion();
+        } else if (Hawk.USING_PLIB) {
             return ProtocolLibrary.getProtocolManager().getProtocolVersion(p);
+        }
         if(Hawk.getServerVersion() == 7) {
             net.minecraft.server.v1_7_R4.PlayerConnection pConnection = ((org.bukkit.craftbukkit.v1_7_R4.entity.CraftPlayer) p).getHandle().playerConnection;
             if(pConnection == null)


### PR DESCRIPTION
Added PacketEvents as an optional dependency, and prioritized it over ProtocolLib. PacketEvents 1.8 hasn't released yet, I DMed you the current latest dev build, I don't recommend making a new Hawk release yet and then having people download older versions with bugs. 
