### PR TITLE
Fix memory leak on Check

### DIFF
--- a/src/me/islandscout/hawk/check/Check.java
+++ b/src/me/islandscout/hawk/check/Check.java
@@ -254,7 +254,8 @@ public abstract class Check<E extends Event> {
 
     //to be overridden by checks
     public void removeData(Player p) {
-        lastFlagTimes.clear();
+        UUID uuid = p.getUniqueId();
+        lastFlagTimes.remove(uuid); 
     }
 
     @Override

--- a/src/me/islandscout/hawk/check/Check.java
+++ b/src/me/islandscout/hawk/check/Check.java
@@ -253,7 +253,9 @@ public abstract class Check<E extends Event> {
     }
 
     //to be overridden by checks
-    public void removeData(Player p) {}
+    public void removeData(Player p) {
+        lastFlagTimes.clear();
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
This is not a problem when there are few flags, but if it is exceeded it can strangle the buffer causing the above mentioned.